### PR TITLE
Point to fork of GXI, upstream is dead

### DIFF
--- a/frontends.md
+++ b/frontends.md
@@ -21,7 +21,7 @@ Here are some front-ends in various stages of development:
 
 * [xi-electron](https://github.com/acheronfail/xi-electron), a cross-platform front-end based on web-technologies.
 
-* [gxi](https://github.com/bvinc/gxi), a GTK+ front-end written in Rust.
+* [gxi](https://github.com/Cogitri/gxi), a GTK+ front-end written in Rust. Forked from https://github.com/bvinc/gxi, which was abandoned.
 
 * [xi-win](https://github.com/xi-editor/xi-win), an experimental Windows front-end written in Rust.
 


### PR DESCRIPTION
This has already been done in the xi-editor repo, so it should be done for the website too.